### PR TITLE
Fix minimize test & compile plugin

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -40,18 +40,22 @@ export default class RtlCssPlugin implements webpack.Plugin {
             map: (sourcemap === undefined && !!devtool) || !!sourcemap
         };
 
-        compiler.hooks.emit.tap(pluginName, compilation => {
-            compilation.chunks.forEach(chunk => {
-                chunk.files.filter(isCss).forEach((chunkFilename: string) => {
-                    const asset: Source = compilation.assets[chunkFilename];
-                    const result = rtlcss.configure(config).process(asset.source(), postcssOptions);
-                    const rawSource = new RawSource(result.css);
-                    const assetFilename = compilation.getPath(filename as string, {
-                        chunk
+        compiler.plugin('this-compilation', (compilation) => {
+            compilation.plugin('optimize-chunk-assets', (chunks: Array<any>, done: Function) => {
+                chunks.forEach(chunk => {
+                    chunk.files.filter(isCss).forEach((chunkFilename: string) => {
+                        const asset: Source = compilation.assets[chunkFilename];
+                        const result = rtlcss.configure(config).process(asset.source(), postcssOptions);
+                        const rawSource = new RawSource(result.css);
+                        const assetFilename = compilation.getPath(filename as string, {
+                            chunk
+                        });
+                        compilation.assets[assetFilename] = rawSource;
                     });
-                    compilation.assets[assetFilename] = rawSource;
                 });
+                done();
             });
         });
     }
 }
+

--- a/tests/cases/minimize/expected.css
+++ b/tests/cases/minimize/expected.css
@@ -1,1 +1,1 @@
-.example{direction:rtl;margin:0;padding:1em 1em .5em 2em;background-color:#353639;font-family:Droid Sans,sans-serif;font-size:16px}
+.example{direction:rtl;margin:0;padding:1em 1em .5em 2em;background-color:#353639;font-family:Droid Arabic Kufi,Droid Sans,sans-serif;font-size:14px}


### PR DESCRIPTION
The `tests/minimize/expected.css` file doesn't reflect what `rtlcss` should do.

- Edited said `css` file
- Used `optimize-chunk-assets` hook to build rtl files